### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,1 @@
+bom: hardware/threeboard.kicad_pcb


### PR DESCRIPTION
Hey, I thought this would be a nice project to add to https://kitspace.org. The idea of Kitspace is to make it as easy as possible to actually build people's open source hardware designs.

All that's required to add your project is to merge this PR. It includes a kitspace.yaml manifest that helps us find the right files. After you merge this the Kitspace page will keep updating with your repo in the future.

[Here is a preview](http://add-threeboard.preview.kitspace.org/boards/github.com/kitspace-forks/threeboard/) of what your project would look like. If you have any questions don't hesitate to ask.

As you can see, we can't get any "buy parts" links from your project yet. If you'd like to improve the bill of materials we have an open source tool called [BOM Builder](https://kitspace.org/bom-builder) to help with that. Please email info@kitspace.org and we'll send you a link.
